### PR TITLE
Add a property to the Tasklist widget to disable automatic switching between buttons using the scroll wheel.

### DIFF
--- a/libmatewnck/tasklist.c
+++ b/libmatewnck/tasklist.c
@@ -191,6 +191,8 @@ struct _MatewnckTasklistPrivate
   
   gboolean include_all_workspaces;
   
+  gboolean enable_scroll_wheel;
+
   /* Calculated by update_lists */
   GList *class_groups;
   GList *windows;
@@ -721,6 +723,7 @@ matewnck_tasklist_init (MatewnckTasklist *tasklist)
   tasklist->priv->active_class_group = NULL;
 
   tasklist->priv->include_all_workspaces = FALSE;
+  tasklist->priv->enable_scroll_wheel = TRUE;
 
   tasklist->priv->class_groups = NULL;
   tasklist->priv->windows = NULL;
@@ -1089,6 +1092,27 @@ matewnck_tasklist_set_include_all_workspaces (MatewnckTasklist *tasklist,
   tasklist->priv->include_all_workspaces = include_all_workspaces;
   matewnck_tasklist_update_lists (tasklist);
   gtk_widget_queue_resize (GTK_WIDGET (tasklist));
+}
+
+/**
+ * matewnck_tasklist_set_scroll_wheel:
+ * @tasklist: a #MatewnckTasklist.
+ * @enable_scroll_wheel: whether to switch windows on scroll wheel events
+ *
+ * Sets @tasklist to switch windows when the mouse scroll wheel is turned.
+ */
+void
+matewnck_tasklist_set_scroll_wheel (MatewnckTasklist *tasklist,
+                                    gboolean          enable_scroll_wheel)
+{
+  g_return_if_fail (MATEWNCK_IS_TASKLIST (tasklist));
+
+  enable_scroll_wheel = (enable_scroll_wheel != 0);
+
+  if (tasklist->priv->enable_scroll_wheel == enable_scroll_wheel)
+    return;
+  
+  tasklist->priv->enable_scroll_wheel = enable_scroll_wheel;
 }
 
 /**
@@ -2177,6 +2201,9 @@ matewnck_tasklist_scroll_cb (MatewnckTasklist *tasklist,
   GList *window;
   gint row = 0;
   gint col = 0;
+
+  if (!tasklist->priv->enable_scroll_wheel)
+    return TRUE;
 
   window = g_list_find (tasklist->priv->windows,
                         tasklist->priv->active_task);

--- a/libmatewnck/tasklist.h
+++ b/libmatewnck/tasklist.h
@@ -101,6 +101,8 @@ void matewnck_tasklist_set_button_relief (MatewnckTasklist *tasklist,
                                       GtkReliefStyle relief);
 void matewnck_tasklist_set_orientation(MatewnckTasklist *tasklist,
                                        GtkOrientation orient);
+void matewnck_tasklist_set_scroll_wheel (MatewnckTasklist *tasklist,
+                                         gboolean          enable_scroll_wheel);
 #ifndef MATEWNCK_DISABLE_DEPRECATED
 void matewnck_tasklist_set_minimum_width (MatewnckTasklist *tasklist, gint size);
 gint matewnck_tasklist_get_minimum_width (MatewnckTasklist *tasklist);


### PR DESCRIPTION
(Requires a corresponding change in mate-panel to be useful...)
